### PR TITLE
Update connection logic to prevent errors

### DIFF
--- a/src/main/java/com/github/brainlag/nsq/NSQConsumer.java
+++ b/src/main/java/com/github/brainlag/nsq/NSQConsumer.java
@@ -1,6 +1,7 @@
 package com.github.brainlag.nsq;
 
 import com.github.brainlag.nsq.callbacks.ConnectErrorCallback;
+import com.github.brainlag.nsq.callbacks.ConnectErrorType;
 import com.github.brainlag.nsq.callbacks.NSQErrorCallback;
 import com.github.brainlag.nsq.callbacks.NSQMessageCallback;
 import com.github.brainlag.nsq.exceptions.NoConnectionsException;
@@ -203,7 +204,7 @@ public class NSQConsumer implements Closeable {
             // very broad intentionally; that way users of the lib can determine which exceptions they care about
             // and handle them appropriately
             if (connectErrorCallback != null) {
-                connectErrorCallback.error(e);
+                connectErrorCallback.error(e, ConnectErrorType.disconnect);
             } else {
                 throw e;
             }
@@ -242,7 +243,7 @@ public class NSQConsumer implements Closeable {
                 // very broad intentionally; that way users of the lib can determine which exceptions they care about
                 // and handle them appropriately
                 if (connectErrorCallback != null) {
-                    connectErrorCallback.error(e);
+                    connectErrorCallback.error(e, ConnectErrorType.update);
                 } else {
                     throw e;
                 }

--- a/src/main/java/com/github/brainlag/nsq/callbacks/ConnectErrorCallback.java
+++ b/src/main/java/com/github/brainlag/nsq/callbacks/ConnectErrorCallback.java
@@ -1,0 +1,17 @@
+package com.github.brainlag.nsq.callbacks;
+
+import java.io.IOException;
+
+/**
+ * Functional interface for handling errors encountered during the connection phase.
+ *
+ * This allows one to listen for exceptions in the `NSQConsumer#connect` operations and react
+ * in an appropriate way, including raising exceptions of its own. If an exception is raised, it
+ * must be of type IOException
+ *
+ * @author Josh Wickham
+ */
+@FunctionalInterface
+public interface ConnectErrorCallback {
+    void error(Exception e);
+}

--- a/src/main/java/com/github/brainlag/nsq/callbacks/ConnectErrorCallback.java
+++ b/src/main/java/com/github/brainlag/nsq/callbacks/ConnectErrorCallback.java
@@ -1,7 +1,5 @@
 package com.github.brainlag.nsq.callbacks;
 
-import java.io.IOException;
-
 /**
  * Functional interface for handling errors encountered during the connection phase.
  *
@@ -13,5 +11,5 @@ import java.io.IOException;
  */
 @FunctionalInterface
 public interface ConnectErrorCallback {
-    void error(Exception e);
+    void error(Exception e, ConnectErrorType errorType);
 }

--- a/src/main/java/com/github/brainlag/nsq/callbacks/ConnectErrorType.java
+++ b/src/main/java/com/github/brainlag/nsq/callbacks/ConnectErrorType.java
@@ -1,0 +1,10 @@
+package com.github.brainlag.nsq.callbacks;
+
+/**
+ * <description goes here>
+ *
+ * @author Josh Wickham
+ */
+public enum ConnectErrorType {
+    disconnect, update;
+}


### PR DESCRIPTION
Use ImmutableSet and Iterators to prevent ConcurrentModificationExceptions.
Introduce a ConnectErrorHandler so users of this library can handle any
errors encountered during connection instead of having the errors just
get swallowed in a different thread which causes the connection timer to
fail and eventually lose servers during autoscaling.