### PR TITLE
LIFE-12350: Queuing Changes

### DIFF
--- a/LIFE360-README.md
+++ b/LIFE360-README.md
@@ -1,0 +1,51 @@
+# Building JavaNSQClient 
+
+Due to name lookups, running the unit tests requires shutting down docker360
+nsq-related services (nsqlookupd, nsqd, and optionally nsqadmin) and running
+them in a local shell. Once that has been done, you may run
+
+```sh
+make build
+```
+
+To build without testing
+```sh
+make no-test
+```
+
+# Adding/updating JavaNSQClient to a Project
+
+Until such time as all of our changes are incorporated into the upstream project,
+adding JavaNSQClient involves building the client locally and adding the `.jar`
+file to the project. We are using the convention of changing the version to
+`LIFE360#` where `#` is the build number.
+
+```sh
+# in the project
+mkdir libs
+
+# in JavaNSQClient 
+make build
+cp target/nsq-client-1.0.0.RC4.jar <PROJECT_DIR>/libs/nsq-client-1.0.0.LIFE3609.jar
+
+# in the project
+vi build.gradle
+# add
+repositories {
+    flatDir name: "localLibs", dirs: "$projectDir/libs"
+    ...
+}
+# add
+dependencies {
+    ...
+    // nsq client
+    compile group: 'com.github.brainlag', name: 'nsq-client', version: '1.0.0.LIFE3609'
+
+    // netty (for nsq)
+    compile group: 'io.netty', name: 'netty-all', version: '4.0.39.Final'
+    ...
+}
+
+git add build.gradle libs/nsq-client-1.0.0.LIFE3609.jar
+git commit
+```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+VERSION_BASE=1.0.0.RC4
+VERSION_LIFE360=${VERSION_BASE}.LIFE360
+
+build:
+	mvn package
+
+install: build
+	mvn install:install-file -Dfile=target/nsq-client-${VERSION_BASE}.jar -DgroupId=com.github.brainlag -DartifactId=nsq-client -Dversion=${VERSION_LIFE360} -Dpackaging=jar
+
+no-test:
+	mvn -Dmaven.test.skip=true package
+
+.PHONY: build install no-test

--- a/src/main/java/com/github/brainlag/nsq/Connection.java
+++ b/src/main/java/com/github/brainlag/nsq/Connection.java
@@ -20,8 +20,11 @@ import io.netty.util.AttributeKey;
 import org.apache.logging.log4j.LogManager;
 
 import java.net.InetSocketAddress;
+import java.net.Inet4Address;
+import java.net.UnknownHostException;
 import java.util.Date;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -34,8 +37,10 @@ public class Connection {
     private final Channel channel;
     private NSQConsumer consumer = null;
     private NSQErrorCallback errorCallback = null;
-    private final LinkedBlockingQueue<NSQCommand> requests = new LinkedBlockingQueue<>(1);
-    private final LinkedBlockingQueue<NSQFrame> responses = new LinkedBlockingQueue<>(1);
+    // This functions as a producer mutex
+    private final BlockingQueue<NSQCommand> requests = new ArrayBlockingQueue<>(1, true);
+    // Should only need to hold a single response per request but ¯\_(ツ)_/¯
+    private final BlockingQueue<NSQFrame> responses = new ArrayBlockingQueue<>(10, true);
     private static EventLoopGroup defaultGroup = null;
     private final EventLoopGroup eventLoopGroup;
     private final NSQConfig config;
@@ -44,37 +49,40 @@ public class Connection {
     private volatile AtomicReference<Long> lastHeartbeatSuccess = new AtomicReference<Long>(System.currentTimeMillis());
 
 
-    public Connection(final ServerAddress serverAddress, final NSQConfig config) throws NoConnectionsException {
+    public Connection(final ServerAddress serverAddress, final NSQConfig config) throws NoConnectionsException, UnknownHostException {
         this.address = serverAddress;
         this.config = config;
         final Bootstrap bootstrap = new Bootstrap();
-        eventLoopGroup = config.getEventLoopGroup() != null ? config.getEventLoopGroup() : getDefaultGroup();
+        eventLoopGroup = (config.getEventLoopGroup() == null) ? getDefaultGroup() : config.getEventLoopGroup();
+        LogManager.getLogger(this).info("Using {} EventLoopGroup",
+                                        (config.getEventLoopGroup() == null) ? "default" : "configured");
         bootstrap.group(eventLoopGroup);
         bootstrap.channel(NioSocketChannel.class);
         bootstrap.handler(new NSQClientInitializer());
         // Start the connection attempt.
-        final ChannelFuture future = bootstrap.connect(new InetSocketAddress(serverAddress.getHost(),
-                serverAddress.getPort()));
+        // FORCE ipv4 for now
+        final ChannelFuture future = bootstrap.connect(new InetSocketAddress(Inet4Address.getByName(serverAddress.getHost()),
+                                                                             serverAddress.getPort()));
 
         // Wait until the connection attempt succeeds or fails.
         channel = future.awaitUninterruptibly().channel();
         if (!future.isSuccess()) {
             throw new NoConnectionsException("Could not connect to server", future.cause());
         }
-        LogManager.getLogger(this).info("Created connection: " + serverAddress.toString());
+        LogManager.getLogger(this).info("Created connection: {}", serverAddress.toString());
         this.channel.attr(STATE).set(this);
         final ByteBuf buf = Unpooled.buffer();
         buf.writeBytes(MAGIC_PROTOCOL_VERSION);
         channel.write(buf);
         channel.flush();
 
-        //identify
+        // identify
         final NSQCommand ident = NSQCommand.identify(config.toString().getBytes());
 
         try {
             final NSQFrame response = commandAndWait(ident);
             if (response != null) {
-                LogManager.getLogger(this).info("Server identification: " + ((ResponseFrame) response).getMessage());
+                LogManager.getLogger(this).info("Server identification: {}", ((ResponseFrame) response).getMessage());
             }
         } catch (final TimeoutException e) {
             LogManager.getLogger(this).error("Creating connection timed out", e);
@@ -94,14 +102,11 @@ public class Connection {
     }
 
     public boolean isRequestInProgress() {
-        return requests.size() > 0;
+        return !requests.isEmpty();
     }
 
     public boolean isHeartbeatStatusOK() {
-        if (System.currentTimeMillis() - lastHeartbeatSuccess.get() > HEARTBEAT_MAX_INTERVAL) {
-            return false;
-        }
-        return true;
+        return (System.currentTimeMillis() - lastHeartbeatSuccess.get()) <= HEARTBEAT_MAX_INTERVAL;
     }
 
     public void incoming(final NSQFrame frame) {
@@ -110,13 +115,17 @@ public class Connection {
                 heartbeat();
                 return;
             } else {
-                if (!requests.isEmpty()) {
+                if (isRequestInProgress()) {
                     try {
-                        responses.offer(frame, 20, TimeUnit.SECONDS);
+                        responses.put(frame);
                     } catch (final InterruptedException e) {
-                        LogManager.getLogger(this).error("Thread was interruped, probably shuthing down", e);
+                        LogManager.getLogger(this).error("Incoming response: thread was interrupted, probably shutting down", e);
                         close();
                     }
+                }
+                else {
+                    LogManager.getLogger(this).warn("Ignore unmatched incoming response {}",
+						    ((ResponseFrame) frame).getMessage());
                 }
                 return;
             }
@@ -126,7 +135,19 @@ public class Connection {
             if (errorCallback != null) {
                 errorCallback.error(NSQException.of((ErrorFrame) frame));
             }
-            responses.add(frame);
+            LogManager.getLogger(this).warn("Adding ErrorFrame to responses");
+            if (isRequestInProgress()) {
+                try {
+                    responses.put(frame);
+                } catch (final InterruptedException e) {
+                    LogManager.getLogger(this).error("Incoming error: thread was interrupted, probably shutting down", e);
+                    close();
+                }
+            }
+            else {
+                LogManager.getLogger(this).warn("Unmatched incoming error {}",
+                                                ((ErrorFrame) frame).getErrorMessage());
+            }
             return;
         }
 
@@ -157,33 +178,27 @@ public class Connection {
     }
 
     public void close() {
-        LogManager.getLogger(this).info("Closing  connection: " + this);
+        LogManager.getLogger(this).info("Closing connection: {}", this);
         channel.disconnect();
     }
 
     public NSQFrame commandAndWait(final NSQCommand command) throws TimeoutException {
         try {
-            if (!requests.offer(command, 15, TimeUnit.SECONDS)) {
-                throw new TimeoutException("command: " + command + " timedout");
-            }
+            requests.put(command);
 
-            responses.clear(); //clear the response queue if needed.
+            responses.clear(); // clear the response queue
             final ChannelFuture fut = command(command);
 
             if (!fut.await(15, TimeUnit.SECONDS)) {
-                throw new TimeoutException("command: " + command + " timedout");
+                throw new TimeoutException("await command: " + command + " timedout");
             }
 
-            final NSQFrame frame = responses.poll(15, TimeUnit.SECONDS);
-            if (frame == null) {
-                throw new TimeoutException("command: " + command + " timedout");
-            }
-
-            requests.poll(); //clear the request object
+            final NSQFrame frame = responses.take();
+            requests.poll(); // let other threads request
             return frame;
         } catch (final InterruptedException e) {
             close();
-            LogManager.getLogger(this).warn("Thread was interruped!", e);
+            LogManager.getLogger(this).warn("Thread was interrupted!", e);
         }
         return null;
     }

--- a/src/main/java/com/github/brainlag/nsq/NSQConsumer.java
+++ b/src/main/java/com/github/brainlag/nsq/NSQConsumer.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.core.jmx.Server;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
@@ -98,6 +99,9 @@ public class NSQConsumer implements Closeable {
             return connection;
         } catch (final NoConnectionsException e) {
             LogManager.getLogger(this).warn("Could not create connection to server {}", serverAddress.toString(), e);
+            return null;
+        } catch (final UnknownHostException e) {
+            LogManager.getLogger(this).warn("Unknown server {}", serverAddress.toString(), e);
             return null;
         }
     }
@@ -268,6 +272,7 @@ public class NSQConsumer implements Closeable {
     }
 
     private Set<ServerAddress> lookupAddresses() {
+        LogManager.getLogger(this).debug("Running lookup for topic {}", topic);
         return lookup.lookup(topic);
     }
 

--- a/src/main/java/com/github/brainlag/nsq/lookup/DefaultNSQLookup.java
+++ b/src/main/java/com/github/brainlag/nsq/lookup/DefaultNSQLookup.java
@@ -36,7 +36,6 @@ public class DefaultNSQLookup implements NSQLookup {
     @Override
     public Set<ServerAddress> lookup(String topic) {
         Set<ServerAddress> addresses = Sets.newHashSet();
-
         for (String addr : getLookupAddresses()) {
             try {
                 String topicEncoded = URLEncoder.encode(topic, Charsets.UTF_8.name());
@@ -56,6 +55,7 @@ public class DefaultNSQLookup implements NSQLookup {
         if (addresses.isEmpty()) {
             LogManager.getLogger(this).warn("Unable to connect to any NSQ Lookup servers, servers tried: {} on topic: {}", this.addresses, topic);
         }
+        LogManager.getLogger(this).debug("Found {} addresses for topic {}", addresses.size(), topic);
         return addresses;
     }
 


### PR DESCRIPTION
- attempt to restrict to IPV4 addresses
- use fair blocking queue
- permit more than one response to arrive
- requests block with no timeout (netty channel await() still uses a timeout)
- add a how-to-build README